### PR TITLE
Test error code now returns number of failures

### DIFF
--- a/test/fab_tests.c
+++ b/test/fab_tests.c
@@ -165,5 +165,5 @@ int main() {
     CU_basic_set_mode(CU_BRM_VERBOSE);
     CU_basic_run_tests();
     CU_cleanup_registry();
-    return CU_get_error();
+    return CU_get_number_of_failures();
 }

--- a/test/fab_tests.c
+++ b/test/fab_tests.c
@@ -165,5 +165,5 @@ int main() {
     CU_basic_set_mode(CU_BRM_VERBOSE);
     CU_basic_run_tests();
     CU_cleanup_registry();
-    return CU_get_number_of_failures();
+    return CU_get_number_of_tests_failed();
 }

--- a/test/fab_tests.c
+++ b/test/fab_tests.c
@@ -164,6 +164,7 @@ int main() {
 
     CU_basic_set_mode(CU_BRM_VERBOSE);
     CU_basic_run_tests();
+    int errCode = CU_get_number_of_tests_failed();
     CU_cleanup_registry();
-    return CU_get_number_of_tests_failed();
+    return errCode;
 }


### PR DESCRIPTION
Right now if any of the tests in libfab fail when run the testing framework will still return 0. This is because it is returning `CU_get_error()` which only returns whether or not the unit testing framework encountered an error, but not the status of tests.

I changed the return statement in the testing framework to return the number of failed tests.
